### PR TITLE
fix: 病句

### DIFF
--- a/src/ch13-02-iterators.md
+++ b/src/ch13-02-iterators.md
@@ -76,7 +76,7 @@ fn iterator_demonstration() {
 
 ### 消费迭代器的方法
 
-`Iterator` trait 有一系列不同的由标准库提供默认实现的方法；你可以在 `Iterator` trait 的标准库 API 文档中找到所有这些方法。一些方法在其定义中调用了 `next` 方法，这也就是为什么在实现 `Iterator` trait 时要求实现 `next` 方法的原因。
+`Iterator` trait 有一系列不同的由标准库提供默认实现的方法；你可以在 `Iterator` trait 的标准库 API 文档中找到所有这些方法。一些方法在其定义中调用了 `next` 方法，这就是为什么在实现 `Iterator` trait 时要求实现 `next` 方法。
 
 这些调用 `next` 方法的方法被称为 **消费适配器**（*consuming adaptors*），因为调用他们会消耗迭代器。一个消费适配器的例子是 `sum` 方法。这个方法获取迭代器的所有权并反复调用 `next` 来遍历迭代器，因而会消费迭代器。当其遍历每一个项时，它将每一个项加总到一个总和并在迭代完成时返回总和。示例 13-16 有一个展示 `sum` 方法使用的测试：
 


### PR DESCRIPTION
原文是: which is why you’re required to implement the next method when implementing the Iterator trait.
翻译为 为什么...的原因 属于语义重复