### PR TITLE
fix: The Rust Programming Language 11.3 中文翻译错误

### DIFF
--- a/src/ch11-03-test-organization.md
+++ b/src/ch11-03-test-organization.md
@@ -202,6 +202,7 @@ fn it_adds_two() {
 #### 二进制 crate 的集成测试
 
 如果项目是二进制 crate 并且只包含 *src/main.rs* 而没有 *src/lib.rs*，这样就不可能在 *tests* 目录创建集成测试并使用 `use` 语句导入 *src/main.rs* 中定义的函数。只有库 crate 才会向其他 crate 暴露了可供调用和使用的函数；二进制 crate 只意在单独运行。
+
 这就是 Rust 二进制项目明确采用 *src/main.rs* 调用 *src/lib.rs* 中的逻辑的原因之一。通过这种结构，集成测试 **就可以** 通过 `use` 测试库 crate 中的主要功能了，而如果这些重要的功能没有问题的话，*src/main.rs* 中的少量代码也就会正常工作且不需要测试。
 
 ## 总结

--- a/src/ch11-03-test-organization.md
+++ b/src/ch11-03-test-organization.md
@@ -201,9 +201,8 @@ fn it_adds_two() {
 
 #### 二进制 crate 的集成测试
 
-如果项目是二进制 crate 并且只包含 *src/main.rs* 而没有 *src/lib.rs*，这样就不可能在 *tests* 目录创建集成测试并使用 `extern crate` 导入 *src/main.rs* 中定义的函数。只有库 crate 才会向其他 crate 暴露了可供调用和使用的函数；二进制 crate 只意在单独运行。
-
-为什么 Rust 二进制项目的结构明确采用 *src/main.rs* 调用 *src/lib.rs* 中的逻辑的方式？因为通过这种结构，集成测试 **就可以** 通过 `extern crate` 测试库 crate 中的主要功能了，而如果这些重要的功能没有问题的话，*src/main.rs* 中的少量代码也就会正常工作且不需要测试。
+如果项目是二进制 crate 并且只包含 *src/main.rs* 而没有 *src/lib.rs*，这样就不可能在 *tests* 目录创建集成测试并使用 `use` 语句导入 *src/main.rs* 中定义的函数。只有库 crate 才会向其他 crate 暴露了可供调用和使用的函数；二进制 crate 只意在单独运行。
+这就是 Rust 二进制项目明确采用 *src/main.rs* 调用 *src/lib.rs* 中的逻辑的原因之一。通过这种结构，集成测试 **就可以** 通过 `use` 测试库 crate 中的主要功能了，而如果这些重要的功能没有问题的话，*src/main.rs* 中的少量代码也就会正常工作且不需要测试。
 
 ## 总结
 


### PR DESCRIPTION
# 原文
![image](https://user-images.githubusercontent.com/57229631/172105328-6dc11fce-2958-441f-a45e-c9de6b5ddaa9.png)

# extern 和 use
https://doc.rust-lang.org/edition-guide/rust-2018/path-changes.html